### PR TITLE
fix forgotten:pass --device arg to retinaface constructor

### DIFF
--- a/face_pixelizer.py
+++ b/face_pixelizer.py
@@ -138,7 +138,9 @@ if __name__ == "__main__":
     # Setup model
 
     face_pixelizer = FacePixelizer(
-        input_size=512, state_dict="retinaface_mobilenet_0.25.pth"
+        input_size=512,
+        state_dict="retinaface_mobilenet_0.25.pth",
+        device=args.device
     )
 
     # Inference


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the CHANGELOG?

## What does this PR do?
Fixes --device arg management, pass it to retinaface constructor (I had forgotten)